### PR TITLE
misc: Add support of array in map

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -112,6 +112,8 @@ module ActiveRecord
           :datetime
         when /Date/
           :date
+        when /Array/
+          type
         else
           :string
         end
@@ -267,6 +269,8 @@ module ActiveRecord
         case value
         when Array
           '[' + value.map { |v| quote(v) }.join(', ') + ']'
+        when Hash
+          '{' + value.map { |k, v| "#{quote(k)}: #{quote(v)}" }.join(', ') + '}'
         else
           super
         end

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -175,6 +175,7 @@ HEADER
       if column.type == :map
         spec[:key_type] = "\"#{column.key_type}\""
         spec[:value_type] = "\"#{column.value_type}\""
+        spec[:array] = nil
       end
 
       spec.merge(super).compact


### PR DESCRIPTION
This PR adds the support of any type for Clickhouse Map key or value

Example:
```ruby
create_table :my_table do |t|
  t.map :filters, key_type: :string, value_type: 'Array(String)', null: false
  t.map :grouped_by, key_type: :string, value_type: :string, null: false
end
```